### PR TITLE
TopBar fixes

### DIFF
--- a/apps/genetics/src/config.js
+++ b/apps/genetics/src/config.js
@@ -8,6 +8,7 @@ const config = {
   platformUrl: window.configPlatformUrl
     ? window.configPlatformUrl.replace(/\/$/, '')
     : 'https://platform.opentargets.org',
+  showTopBar: window.configShowTopBar ?? false,
 };
 
 export default config;

--- a/packages/ui/src/GlobalSearch.jsx
+++ b/packages/ui/src/GlobalSearch.jsx
@@ -49,6 +49,8 @@ const useStyles = makeStyles((theme) => ({
     right: "10px",
   },
   modal: {
+    // leave the space that will be hidden behind the logo bar unused
+    paddingTop: (window.configShowTopBar ?? false) ? "50px" : "",
     "& .MuiDialog-scrollPaper": {
       alignItems: "start",
       "& .MuiDialog-paperWidthSm": {


### PR DESCRIPTION
- Add config option to enable showing TopBar in OTG
- Fix bug that causes TopBar to overlap with the search box at the top of the page when you click on it to search a term (only when TopBar is active, i.e. `configShowTopBar = true`) - both OTG & OTP