### PR TITLE
Update the base image for security again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bookworm as build
+FROM node:18 as build
 # make sure app variable is set and valid
 ARG app=""
 RUN : "${app:?Missing --build-arg app}"
@@ -12,7 +12,7 @@ RUN yarn --network-timeout 100000
 RUN yarn build:$app
 RUN mv ./apps/$app/bundle-$app/ ./bundle/
 
-FROM node:16-bookworm
+FROM node:18
 RUN npm install --location=global serve
 COPY --from=build /tmp/app/bundle/ /var/www/app/
 WORKDIR /var/www/app/


### PR DESCRIPTION
The node:16 image tag is no longer being maintained with OS package updates, so vulnerabilities have started to build up in it.