### PR TITLE
Add metrics page package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 .turbo
 # Local Netlify folder
 .netlify
+
+# .npmrc
+.npmrc

--- a/packages/data-metrics-plugin/.npmignore
+++ b/packages/data-metrics-plugin/.npmignore
@@ -1,0 +1,1 @@
+PUBLISHING.md

--- a/packages/data-metrics-plugin/DataMetricsPage.tsx
+++ b/packages/data-metrics-plugin/DataMetricsPage.tsx
@@ -1,0 +1,75 @@
+import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
+import { useEffect, useState } from "react";
+import { BasePage, Header } from "ui";
+import DataMetricsTotalCards from "./DataMetricsTotalCards";
+import DownloadLink from "./DownloadLink";
+import EvidenceDataMetricsSection from "./EvidenceDataMetricsSection";
+import { DataMetricsPageProps, Metric } from "./types";
+
+function parseCSV(text: string): Metric[] {
+  if (!text) return [];
+  const lines = text.trim().split(/\r?\n/);
+  const headers = lines[0].split(",");
+  return lines.slice(1).map((line) => {
+    const values = line.split(",");
+    const obj: Metric = {};
+    headers.forEach((h, i) => {
+      obj[h] = values[i];
+    });
+    return obj;
+  });
+}
+
+function DataMetricsPage({
+  currentRelease,
+  previousRelease,
+  currentMetricsFile,
+  previousMetricsFile,
+}: DataMetricsPageProps) {
+  const [metrics, setMetrics] = useState<Metric[]>([]);
+  const [prevMetrics, setPrevMetrics] = useState<Metric[]>([]);
+
+  useEffect(() => {
+    fetch(`./${currentMetricsFile}`)
+      .then((response) => response.text())
+      .then((text) => {
+        const parsed = parseCSV(text);
+        setMetrics(parsed);
+      });
+    fetch(`./${previousMetricsFile}`)
+      .then((response) => response.text())
+      .then((text) => {
+        const parsed = parseCSV(text);
+        setPrevMetrics(parsed);
+      });
+  }, [currentMetricsFile, previousMetricsFile]);
+
+  return (
+    <BasePage>
+      <>
+        <Header
+          loading={false}
+          title={"Data Metrics"}
+          subtitle={`v${currentRelease}`}
+          Icon={faMagnifyingGlass}
+          externalLinks={
+            <>
+              <DownloadLink
+                title={`Download Metrics v${currentRelease}`}
+                file={currentMetricsFile}
+              />
+              <DownloadLink
+                title={`Download Metrics v${previousRelease} (prev)`}
+                file={previousMetricsFile}
+              />
+            </>
+          }
+        />
+        <DataMetricsTotalCards metrics={metrics} prevMetrics={prevMetrics} />
+        <EvidenceDataMetricsSection metrics={metrics} prevMetrics={prevMetrics} />
+      </>
+    </BasePage>
+  );
+}
+
+export default DataMetricsPage;

--- a/packages/data-metrics-plugin/DataMetricsPieChart.tsx
+++ b/packages/data-metrics-plugin/DataMetricsPieChart.tsx
@@ -1,0 +1,182 @@
+/** biome-ignore-all lint/a11y/noStaticElementInteractions: must be interactive */
+/** biome-ignore-all lint/a11y/useKeyWithClickEvents: no keyboard interactions desired */
+/** biome-ignore-all lint/a11y/useKeyWithMouseEvents: no keyboard interactions desired */
+import { Box } from "@mui/material";
+import * as d3 from "d3";
+import { useRef, useState } from "react";
+import { DataMetricsPieChartProps, Tooltip } from "./types";
+
+// Pie chart for datasource metrics
+function DataMetricsPieChart({ data, width = 520, height = 520 }: DataMetricsPieChartProps) {
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const [tooltip, setTooltip] = useState<Tooltip | null>(null);
+  const [activeLabels, setActiveLabels] = useState<string[]>(data.map((d) => d.label));
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const pie = d3.pie<{ label: string; value: number }>().value((d) => d.value);
+  const arc = d3
+    .arc()
+    .innerRadius(0)
+    .outerRadius(Math.min(width, height) / 2 - 10);
+  // Use a fixed color palette and assign each label a color based on its index in the original data array
+  const colorPalette = d3.schemeCategory10;
+  const labelColorMap: Record<string, string> = {};
+  data.forEach((d, i) => {
+    labelColorMap[d.label] = colorPalette[i % colorPalette.length];
+  });
+  // Only include active datasources
+  const filteredData = data.filter((d) => activeLabels.includes(d.label));
+  const pieData = pie(filteredData);
+  function handleLegendClick(label: string) {
+    setActiveLabels((prev) =>
+      prev.includes(label) ? prev.filter((l) => l !== label) : [...prev, label]
+    );
+  }
+
+  function handleMouseOver(
+    d: d3.PieArcDatum<{ label: string; value: number }>,
+    i: number
+  ) {
+    setHoveredIdx(i);
+    const [x, y] = arc.centroid(d as any);
+    setTooltip({
+      x: x + width / 2,
+      y: y + height / 2,
+      label: d.data.label,
+      value: d.data.value,
+    });
+  }
+
+  function handleMouseOut() {
+    setHoveredIdx(null);
+    setTooltip(null);
+  }
+
+  // Only show label for slices > 6% of total
+  const totalValue = filteredData.reduce((sum, d) => sum + d.value, 0);
+  const minLabelPercent = 0.06;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "center",
+        alignItems: "center",
+        position: "relative",
+      }}
+    >
+      <Box sx={{ position: "relative" }}>
+        <svg ref={svgRef} width={width} height={height}>
+          <title>Data Metrics Pie Chart</title>
+          <g transform={`translate(${width / 2},${height / 2})`}>
+            {pieData.map((d, i) => {
+              const percent = d.data.value / totalValue;
+              const color = labelColorMap[d.data.label];
+              return (
+                <g key={d.data.label}>
+                  <path
+                    d={arc(d as any) ?? undefined}
+                    fill={color}
+                    stroke={hoveredIdx === i ? "#222" : "#fff"}
+                    strokeWidth={hoveredIdx === i ? 3 : 1}
+                    style={{
+                      cursor: "pointer",
+                      opacity: hoveredIdx === null || hoveredIdx === i ? 1 : 0.7,
+                    }}
+                    onMouseOver={() => handleMouseOver(d, i)}
+                    onMouseOut={handleMouseOut}
+                  />
+                  {/* Only show label if slice is large enough */}
+                  {percent > minLabelPercent && (
+                    <text
+                      transform={`translate(${arc.centroid(d as any)})`}
+                      textAnchor="middle"
+                      alignmentBaseline="middle"
+                      fontSize={14}
+                      fill="#fff"
+                      pointerEvents="none"
+                      style={{ textShadow: "0 1px 4px #000" }}
+                    >
+                      {d.data.label}
+                    </text>
+                  )}
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+        {tooltip && (
+          <Box
+            sx={{
+              position: "absolute",
+              left: tooltip.x,
+              top: tooltip.y,
+              background: "rgba(0,0,0,0.85)",
+              color: "#fff",
+              px: 2,
+              py: 1,
+              borderRadius: 1,
+              pointerEvents: "none",
+              fontSize: 14,
+              zIndex: 10,
+              transform: "translate(-50%, -120%)",
+            }}
+          >
+            <div>
+              <strong>{tooltip.label}</strong>
+            </div>
+            <div>{tooltip.value.toLocaleString()}</div>
+          </Box>
+        )}
+      </Box>
+      {/* Legend for all datasources */}
+      <Box sx={{ ml: 4, minWidth: 120 }}>
+        <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+          {data.map((d) => {
+            const isActive = activeLabels.includes(d.label);
+            const color = labelColorMap[d.label];
+            // Highlight if hovered in pie (find index in filteredData)
+            const filteredIdx = filteredData.findIndex((fd) => fd.label === d.label);
+            return (
+              <li
+                key={d.label}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  marginBottom: 8,
+                  opacity: isActive ? 1 : 0.4,
+                  cursor: "pointer",
+                }}
+                onClick={() => handleLegendClick(d.label)}
+                title={isActive ? "Click to exclude" : "Click to include"}
+              >
+                <span
+                  style={{
+                    width: 18,
+                    height: 18,
+                    background: color,
+                    display: "inline-block",
+                    marginRight: 8,
+                    borderRadius: 4,
+                    border: "1px solid #ccc",
+                  }}
+                />
+                <span
+                  style={{
+                    fontWeight: hoveredIdx === filteredIdx ? "bold" : "normal",
+                    textDecoration: isActive ? "none" : "line-through",
+                  }}
+                >
+                  {d.label}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </Box>
+    </Box>
+  );
+}
+
+export default DataMetricsPieChart;

--- a/packages/data-metrics-plugin/DataMetricsTable.tsx
+++ b/packages/data-metrics-plugin/DataMetricsTable.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { OtTable } from "ui";
+import { DataMetricsTableProps, Row} from "./types";
+
+function DataMetricsTable({ metrics, prevMetrics, variables, sources }: DataMetricsTableProps) {
+  // Define columns for OtTable
+  const columns = [
+    {
+      id: "datasource",
+      label: "Datasource",
+      enableHiding: false,
+      renderCell: (row: Row) => row.datasource.display,
+      exportLabel: "Datasource",
+      propertyPath: "datasource.value",
+    },
+    ...variables.map((variable) => ({
+      id: variable,
+      label: variable,
+      align: "right",
+      renderCell: (row: Row) => row[variable].display,
+      exportLabel: variable,
+      propertyPath: `${variable}.value`,
+    })),
+  ];
+
+  // Prepare rows for OtTable
+  const rows: Row[] = Array.from(sources)
+    .sort()
+    .map((ds) => {
+      const row: Row = {
+        datasource: {
+          display: ds,
+          value: ds,
+        },
+      };
+      for (const variable of variables) {
+        const metric = metrics.find((m) => m.datasourceId === ds && m.variable === variable);
+        const prevMetric = prevMetrics.find(
+          (pm) => pm.datasourceId === ds && pm.variable === variable
+        );
+        if (metric || prevMetric) {
+          const currValue = metric ? Number(metric.value) : 0;
+          const prevValue = prevMetric ? Number(prevMetric.value) : 0;
+          const diff = currValue - prevValue;
+          const pct = prevValue !== 0 ? (diff / prevValue) * 100 : null;
+          let display: React.ReactNode = currValue.toLocaleString();
+          if (prevMetric) {
+            display = (
+              <span>
+                {currValue.toLocaleString()}{" "}
+                <span
+                  style={{
+                    color: diff > 0 ? "green" : diff < 0 ? "red" : undefined,
+                    fontSize: "0.9em",
+                  }}
+                >
+                  {diff > 0 ? "▲" : diff < 0 ? "▼" : ""}{" "}
+                  {diff !== 0 ? Math.abs(diff).toLocaleString() : ""}{" "}
+                  {pct !== null ? `(${pct.toFixed(1)}%)` : ""}
+                </span>
+              </span>
+            );
+          }
+          row[variable] = {
+            display,
+            value: currValue.toString(),
+          };
+        } else {
+          row[variable] = {
+            display: "-",
+            value: "-",
+          };
+        }
+      }
+      return row;
+    });
+
+  return (
+    <OtTable
+      showGlobalFilter={false} // This would require some refactoring to work well. The filter function in OtTable assumes a single value per cell, not an object with display and value. Just using a object would not work because the object is JSX (instead of a value) and cannot be searched.
+      columns={columns}
+      rows={rows}
+      dataDownloaderFileStem={"data-metrics-table"}
+      tableDataLoading={false}
+      verticalHeaders={false}
+      order={"desc"}
+      sortBy={""}
+      defaultSortObj={undefined}
+      dataDownloader={false}
+      query={null as any}
+      variables={{}}
+      showColumnVisibilityControl={false}
+      loading={false}
+      enableMultipleRowSelection={false}
+      getSelectedRows={null as any}
+    />
+  );
+}
+
+export default DataMetricsTable;

--- a/packages/data-metrics-plugin/DataMetricsTotalCards.tsx
+++ b/packages/data-metrics-plugin/DataMetricsTotalCards.tsx
@@ -1,0 +1,92 @@
+import { Card, CardContent, Grid, Typography } from "@mui/material";
+import { DataMetricsTotalCardsProps } from "./types";
+
+const excludeCardPatterns = [
+  "Invalid",
+  "Duplicate",
+  "NullifiedScore",
+  "UnresolvedTarget",
+  "UnresolvedDisease",
+];
+
+function variableToTitle(variable: string): string {
+  let name = variable.replace(/TotalCount$/, "");
+  name = name.replace(/([A-Z])/g, " $1").replace(/^\s+/, "");
+  name = name.charAt(0).toUpperCase() + name.slice(1);
+  return `${name.trim()}`;
+}
+
+function DataMetricsTotalCards({ metrics, prevMetrics }: DataMetricsTotalCardsProps) {
+  // Find all variables in current and previous metrics that should be shown
+  const currVars = metrics
+    .filter(
+      (m) =>
+        m.datasourceId === "all" &&
+        m.variable &&
+        m.variable.endsWith("TotalCount") &&
+        !excludeCardPatterns.some((pattern) => m.variable.includes(pattern))
+    )
+    .map((m) => m.variable);
+
+  const prevVars = prevMetrics
+    .filter(
+      (pm) =>
+        pm.datasourceId === "all" &&
+        pm.variable &&
+        pm.variable.endsWith("TotalCount") &&
+        !excludeCardPatterns.some((pattern) => pm.variable.includes(pattern))
+    )
+    .map((pm) => pm.variable);
+
+  // Union of variables from current and previous
+  const allVars = Array.from(new Set([...currVars, ...prevVars]));
+
+  // Build a list of metric objects for display
+  const allMetrics = allVars.map((variable) => {
+    const curr = metrics.find((m) => m.datasourceId === "all" && m.variable === variable);
+    const prev = prevMetrics.find((pm) => pm.datasourceId === "all" && pm.variable === variable);
+    return {
+      variable,
+      value: curr ? curr.value : 0,
+      prevValue: prev ? prev.value : null,
+    };
+  });
+
+  return (
+    <Grid container spacing={2} sx={{ mb: 3 }}>
+      {allMetrics.map((m) => {
+        const currValue = Number(m.value);
+        const prevValue = m.prevValue !== null ? Number(m.prevValue) : null;
+        let diff = null,
+          pct = null;
+        if (prevValue !== null && !Number.isNaN(prevValue)) {
+          diff = currValue - prevValue;
+          pct = prevValue !== 0 ? (diff / prevValue) * 100 : null;
+        }
+        return (
+          <Grid item xs={12} md={4} key={m.variable}>
+            <Card>
+              <CardContent>
+                <Typography variant="h6">{variableToTitle(m.variable)}</Typography>
+                <Typography variant="h5" color="primary">
+                  {currValue.toLocaleString()}
+                </Typography>
+                {prevValue !== null && !Number.isNaN(prevValue) && diff !== null && (
+                  <Typography
+                    variant="body2"
+                    color={diff > 0 ? "success.main" : diff < 0 ? "error.main" : "text.secondary"}
+                  >
+                    {diff > 0 ? "▲" : diff < 0 ? "▼" : ""} {Math.abs(diff).toLocaleString()} (
+                    {pct !== null ? pct.toFixed(1) : "-"}% vs prev)
+                  </Typography>
+                )}
+              </CardContent>
+            </Card>
+          </Grid>
+        );
+      })}
+    </Grid>
+  );
+}
+
+export default DataMetricsTotalCards;

--- a/packages/data-metrics-plugin/DownloadLink.tsx
+++ b/packages/data-metrics-plugin/DownloadLink.tsx
@@ -1,0 +1,37 @@
+import { Theme } from "@mui/material/styles";
+import { makeStyles } from "@mui/styles";
+import classNames from "classnames";
+import { DownloadLinkProps } from "./types";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  base: {
+    fontSize: "inherit",
+    "text-decoration-color": "transparent",
+    "-webkit-text-decoration-color": "transparent",
+  },
+  baseDefault: {
+    color: theme.palette.primary.main,
+    "&:hover": {
+      color: theme.palette.primary.dark,
+      "text-decoration-color": theme.palette.primary.dark,
+      "-webkit-text-decoration-color": theme.palette.primary.dark,
+    },
+  },
+}));
+
+const DownloadLink = ({ title, file }: DownloadLinkProps) => {
+  const classes = useStyles();
+
+  if (!file) return null;
+
+  return (
+    <span>
+      {title}: {" "}
+      <a className={classNames(classes.base, classes.baseDefault)} href={`/${file}`} download>
+        {file}
+      </a>
+    </span>
+  );
+};
+
+export default DownloadLink;

--- a/packages/data-metrics-plugin/EvidenceDataMetricsSection.tsx
+++ b/packages/data-metrics-plugin/EvidenceDataMetricsSection.tsx
@@ -1,0 +1,128 @@
+import { Box, CircularProgress } from "@mui/material";
+import { VIEW } from "@ot/constants";
+import { SectionItem } from "ui";
+import DataMetricsPieChart from "./DataMetricsPieChart";
+import DataMetricsTable from "./DataMetricsTable";
+import { evidenceDefinition } from "./index";
+import { EvidenceDataMetricsSectionProps } from "./types";
+
+const excludeVariables = [
+  "evidenceFieldNotNullCountByDatasource",
+  "evidenceDistinctFieldsCountByDatasource",
+  "evidenceInvalidCountByDatasource",
+  "evidenceInvalidDistinctFieldsCountByDatasource",
+  "evidenceDuplicateDistinctFieldsCountByDatasource",
+  "evidenceNullifiedScoreDistinctFieldsCountByDatasource",
+  "evidenceUnresolvedTargetDistinctFieldsCountByDatasource",
+  "evidenceUnresolvedDiseaseDistinctFieldsCountByDatasource",
+  "evidenceDuplicateCountByDatasource",
+  "evidenceNullifiedScoreCountByDatasource",
+  "evidenceUnresolvedTargetCountByDatasource",
+  "evidenceUnresolvedDiseaseCountByDatasource",
+  "associationsDirectByDatasourceAUC",
+  "associationsDirectByDatasourceOR",
+  "associationsIndirectByDatasourceAUC",
+  "associationsIndirectByDatasourceOR",
+];
+
+function EvidenceDataMetricsSection({ metrics, prevMetrics }: EvidenceDataMetricsSectionProps) {
+  const isLoading = !metrics.length || !prevMetrics.length;
+  // Table and chart logic
+  const sourcesExcludeList = ["all", "drug", "target"];
+  const sourcesList = Array.from(
+    new Set([
+      ...metrics.map((m) => m.datasourceId).filter((ds) => ds && !sourcesExcludeList.includes(ds)),
+      ...prevMetrics
+        .map((m) => m.datasourceId)
+        .filter((ds) => ds && !sourcesExcludeList.includes(ds)),
+    ])
+  );
+  const variables = Array.from(
+    new Set([
+      ...metrics.map((m) => m.variable).filter(Boolean),
+      ...prevMetrics.map((m) => m.variable).filter(Boolean),
+    ])
+  ).filter((variable) => {
+    if (excludeVariables.includes(variable)) return false;
+    return (
+      metrics.some(
+        (m) =>
+          m.variable === variable &&
+          !sourcesExcludeList.includes(m.datasourceId) &&
+          m.value &&
+          m.value !== "" &&
+          m.value !== "0"
+      ) ||
+      prevMetrics.some(
+        (m) =>
+          m.variable === variable &&
+          !sourcesExcludeList.includes(m.datasourceId) &&
+          m.value &&
+          m.value !== "" &&
+          m.value !== "0"
+      )
+    );
+  });
+
+  // Pie chart data
+  const pieSources = Array.from(
+    new Set(
+      metrics.map((m) => m.datasourceId).filter((ds) => ds && !sourcesExcludeList.includes(ds))
+    )
+  );
+  const pieVariables = Array.from(new Set(metrics.map((m) => m.variable).filter(Boolean))).filter(
+    (variable) => {
+      if (excludeVariables.includes(variable)) return false;
+      return metrics.some(
+        (m) =>
+          m.variable === variable &&
+          !sourcesExcludeList.includes(m.datasourceId) &&
+          m.value &&
+          m.value !== "" &&
+          m.value !== "0"
+      );
+    }
+  );
+  const pieData = pieSources
+    .map((ds) => {
+      const total = pieVariables.reduce((sum, variable) => {
+        const metric = metrics.find((m) => m.datasourceId === ds && m.variable === variable);
+        return sum + (metric ? Number(metric.value) : 0);
+      }, 0);
+      return { label: ds, value: total };
+    })
+    .filter((d) => d.value > 0);
+
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight={200}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+  return (
+    <SectionItem
+      entity={"metrics"}
+      definition={evidenceDefinition}
+      request={{ loading: false, data: { metrics, prevMetrics } }}
+      renderDescription={() => null}
+      renderBody={() => (
+        <DataMetricsTable
+          metrics={metrics}
+          prevMetrics={prevMetrics}
+          variables={variables}
+          sources={sourcesList}
+        />
+      )}
+      renderChart={() => <DataMetricsPieChart data={pieData} />}
+      tags={[]}
+      chipText=""
+      showEmptySection={false}
+      showContentLoading={false}
+      loadingMessage="Loading data. This may take some time..."
+      defaultView={VIEW.table}
+    />
+  );
+}
+
+export default EvidenceDataMetricsSection;

--- a/packages/data-metrics-plugin/PUBLISHING.md
+++ b/packages/data-metrics-plugin/PUBLISHING.md
@@ -1,0 +1,49 @@
+# Publishing to The Hyve GitHub NPM Registry (Public)
+
+This guide explains how to publish the `@thehyve/data-metrics-plugin` package to The Hyve's GitHub NPM registry as a public package.
+
+## Prerequisites
+
+- You must have a GitHub account with permission to publish to the `thehyve` organization.
+- You need a GitHub Personal Access Token (PAT) with `write:packages` and `repo` scopes.
+- Ensure your package version in `package.json` is updated according to semantic versioning.
+
+## 1. Configure `.npmrc`
+
+Create or update a `.npmrc` file in your project root (or home directory):
+
+```ini
+@thehyve:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT
+```
+
+Replace `YOUR_GITHUB_PAT` with your GitHub Personal Access Token.
+
+> **Important:** Add `.npmrc` to your `.gitignore` to avoid leaking your PAT.
+
+
+## 2. Publish the package
+
+Run the following command in the package directory:
+
+```sh
+npm publish
+```
+
+If successful, your package will be published to The Hyve's GitHub npm registry.
+
+## 3. Set the package as public on GitHub
+
+After publishing, you may need to set the package visibility to public using the GitHub web interface:
+
+1. Go to https://github.com/orgs/thehyve/packages (or your organization's Packages page).
+2. Click on the `@thehyve/data-metrics-plugin` package.
+3. Click on "Package settings" (gear icon or settings tab).
+4. Under "Danger Zone" or "Visibility", set the package visibility to **Public**.
+5. Confirm your choice if prompted.
+
+This ensures the package is accessible to everyone, not just your organization.
+
+---
+
+**Note:** This file is for internal documentation and should NOT be included in the published package.

--- a/packages/data-metrics-plugin/README.md
+++ b/packages/data-metrics-plugin/README.md
@@ -70,7 +70,7 @@ import { DataMetricsPage } from "@thehyve/data-metrics-plugin";
 ```
 
 - The component will fetch the CSV files and display the metrics dashboard.
-- Place the metrics CSV files in your public directory or ensure the URLs are accessible from the client.
+- Place the metrics CSV files in your public directory.
 
 ## Components
 

--- a/packages/data-metrics-plugin/README.md
+++ b/packages/data-metrics-plugin/README.md
@@ -1,0 +1,86 @@
+# Data Metrics Plugin
+
+This package provides React components for displaying data metrics for OTP, including summary cards, tables, and charts. The main entry point is the `DataMetricsPage` component.
+
+## Installation
+
+To install this package from The Hyve's GitHub npm registry, you need to configure your project to use the correct registry for the `@thehyve` scope.
+
+### 1. Configure `.npmrc`
+
+Create or update a `.npmrc` file in your project root with the following lines:
+
+```ini
+@thehyve:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT
+```
+
+You need a GitHub Personal Access Token (PAT) with at least `read:packages` scope, even for public packages. Replace `YOUR_GITHUB_PAT` with your token.
+
+> **Important:** Add `.npmrc` to your `.gitignore` file to avoid accidentally pushing your PAT to GitHub.
+
+### 2. Add the dependency
+
+In your project's `package.json`, add:
+
+```json
+"dependencies": {
+  "@thehyve/data-metrics-plugin": "@thehyve/data-metrics-plugin"
+}
+```
+
+### 3. Install dependencies
+
+Run:
+
+```sh
+yarn install
+```
+
+## Usage
+
+### DataMetricsPage
+
+The `DataMetricsPage` component displays a full metrics dashboard, including:
+- Release header
+- Download links for metrics files
+- Summary cards for key metrics
+- Evidence metrics table and pie chart
+
+#### Props
+
+| Prop                | Type     | Description                                 |
+|---------------------|----------|---------------------------------------------|
+| `currentRelease`    | string   | The current release version (e.g. "25.12")  |
+| `previousRelease`   | string   | The previous release version (e.g. "25.09") |
+| `currentMetricsUrl` | string   | Filename or URL for the current metrics CSV  |
+| `previousMetricsUrl`| string   | Filename or URL for the previous metrics CSV |
+
+#### Example
+
+```tsx
+import { DataMetricsPage } from "@thehyve/data-metrics-plugin";
+
+<DataMetricsPage
+  currentRelease="25.12"
+  previousRelease="25.09"
+  currentMetricsUrl="metrics_25-12.csv"
+  previousMetricsUrl="metrics_25-09.csv"
+/>
+```
+
+- The component will fetch the CSV files and display the metrics dashboard.
+- Place the metrics CSV files in your public directory or ensure the URLs are accessible from the client.
+
+## Components
+
+- `DataMetricsPage`: Main dashboard page
+- `DataMetricsTotalCards`: Summary cards for total counts
+- `EvidenceDataMetricsSection`: Table and pie chart for evidence metrics
+- `DownloadLink`: Download link for metrics files
+- `DataMetricsPieChart`: Pie chart for datasource metrics
+- `DataMetricsTable`: Table for metrics comparison
+
+## Development
+
+- Written in TypeScript and React.

--- a/packages/data-metrics-plugin/index.tsx
+++ b/packages/data-metrics-plugin/index.tsx
@@ -1,0 +1,10 @@
+export { default as DataMetricsPage } from "./DataMetricsPage";
+
+export const evidenceDefinition = {
+	id: "dataMetrics",
+	name: "Evidence Metrics",
+	shortName: "EM",
+	hasData: () => {
+		return true;
+	},
+};

--- a/packages/data-metrics-plugin/package.json
+++ b/packages/data-metrics-plugin/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@thehyve/data-metrics-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thehyve/ot-ui-apps.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
+  },
+  "version": "1.0.0",
+  "main": "index.tsx",
+  "types": "index.tsx",
+  "dependencies": {
+    "ui": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/react": "^18.0.0",
+    "@types/classnames": "^2.3.0",
+    "@types/d3": "^7.4.0"
+  }
+}

--- a/packages/data-metrics-plugin/tsconfig.json
+++ b/packages/data-metrics-plugin/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "exclude": ["dist", "build", "node_modules"],
+  "extends": "tsconfig/vite.json",
+  "include": ["*.ts", "*.tsx"],
+}

--- a/packages/data-metrics-plugin/types.ts
+++ b/packages/data-metrics-plugin/types.ts
@@ -1,0 +1,64 @@
+// General metric type
+export type Metric = {
+  [key: string]: string;
+};
+
+// Data metrics page props types
+export interface DataMetricsPageProps {
+  currentRelease: string;
+  previousRelease: string;
+  currentMetricsFile: string;
+  previousMetricsFile: string;
+}
+
+// Pie chart data types
+export interface DataMetricsPieChartProps {
+  data: PieDatum[];
+  width?: number;
+  height?: number;
+}
+
+export interface PieDatum {
+  label: string;
+  value: number;
+}
+
+export interface Tooltip {
+  x: number;
+  y: number;
+  label: string;
+  value: number;
+}
+
+// Table props types
+export interface DataMetricsTableProps {
+  metrics: Metric[];
+  prevMetrics: Metric[];
+  variables: string[];
+  sources: string[];
+}
+
+export type Row = {
+  [variable: string]: {
+    display: React.ReactNode;
+    value: string;
+  };
+};
+
+// Total cards props types
+export interface DataMetricsTotalCardsProps {
+  metrics: Metric[];
+  prevMetrics: Metric[];
+}
+
+// Download link props types
+export interface DownloadLinkProps {
+  title: string;
+  file: string;
+}
+
+// Evidence data metrics section props types
+export interface EvidenceDataMetricsSectionProps {
+  metrics: Metric[];
+  prevMetrics: Metric[];
+}


### PR DESCRIPTION
This PR adds the metrics page plugin.
READMEs are provided on how to install and use the plugin and how to publish it to github.
For reference, the package can be found here including readme: https://github.com/thehyve/ot-ui-apps/pkgs/npm/data-metrics-plugin

@LoesvdBiggelaar and @fedde-s I would recomment you guys to at least look at how this npm package stuff works :)